### PR TITLE
Fix BBC Food, resolves #12

### DIFF
--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -9,14 +9,14 @@ class BBCFood(AbstractScraper):
         return 'bbc.co.uk'
 
     def title(self):
-        return self.soup.find('div', {'class': 'article-title'}).find('h1').get_text()
+        return self.soup.find('h1', {'itemprop': 'name'}).get_text()
 
     def total_time(self):
-        return get_minutes(self.soup.find('span', {'class': 'prepTime'})) +\
-               get_minutes(self.soup.find('span', {'class': 'cookTime'}))
+        return get_minutes(self.soup.find('p', {'itemprop': 'prepTime'})) +\
+            get_minutes(self.soup.find('p', {'itemprop': 'cookTime'}))
 
     def ingredients(self):
-        ingredients_html = self.soup.findAll('p', {'class': "ingredient"})
+        ingredients_html = self.soup.findAll('li', {'itemprop': "ingredients"})
 
         return [
             normalize_string(ingredient.get_text())
@@ -24,7 +24,8 @@ class BBCFood(AbstractScraper):
         ]
 
     def instructions(self):
-        instructions_html = self.soup.findAll('li', {'class': 'instruction'})
+        instructions_html = self.soup.findAll(
+            'li', {'itemprop': 'recipeInstructions'})
 
         return '\n'.join([
             normalize_string(instruction.get_text())


### PR DESCRIPTION
This commit fixes the BBC food parser which is currently broken (see issue #12 ). The fix is as simple as switching to the new itemprop attribute rather than the old classes.

There are new classes we could be using, but it seems like itemprop is the primary identifier for the field and more readable.